### PR TITLE
Update CV2 Version for Compatibility with MarkUs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "markus_exam_matcher"
 version = "0.0.1"
 dependencies = [
     "urllib3==1.26.6",
-    "opencv-python-headless~=4.7.0",
+    "opencv-python-headless==4.5.5.64",
     "torch==2.0.0",
     "torchvision==0.15.1",
     "Pillow==9.3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "markus_exam_matcher"
 version = "0.0.1"
 dependencies = [
     "urllib3==1.26.6",
-    "opencv-python-headless==4.5.2.52",
+    "opencv-python==4.5.5.62",
     "torch==2.0.0",
     "torchvision==0.15.1",
     "Pillow==9.3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "markus_exam_matcher"
 version = "0.0.1"
 dependencies = [
     "urllib3==1.26.6",
-    "opencv-python-headless==4.5.5.64",
+    "opencv-python-headless==4.5.2.52",
     "torch==2.0.0",
     "torchvision==0.15.1",
     "Pillow==9.3.0",


### PR DESCRIPTION
## What?
Changed from using `opencv-python-headless` to `opencv-python` to use a different implementation of `cv2`.

## Why?
The current version of `cv2` was being provided by the library `opencv-python-headless`, yet this library seemed to be incompatible with MarkUs. Import errors internal to the `cv2` library were raised across different versions of the library when the exam matching script ran.

## How?
Switching the dependencies from `opencv-python-headless` to `opencv-python` fixed the internal import errors that were being raised and allowed the Python script to run properly in MarkUs.